### PR TITLE
Fix temp file path generation in FileHelperService

### DIFF
--- a/app/Services/FileHelperService.php
+++ b/app/Services/FileHelperService.php
@@ -32,8 +32,7 @@ class FileHelperService
 
     public function getTempFile(string $ext)
     {
-        return sys_get_temp_dir().''.uniqid('file_').'.'.$ext;
-
+        return sys_get_temp_dir().'/'.uniqid('file_').'.'.$ext;
     }
 
     public function createTemporaryFileFromDoc($fileName, $content): string


### PR DESCRIPTION
Korrigiert fehlenden Slash zwischen sys_get_temp_dir() und Dateiname in getTempFile(), wodurch ungültige Pfade wie /tmpfile_xyz.pdf statt /tmp/file_xyz.pdf erzeugt wurden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)