### PR TITLE
- Nummerkreise wurden nicht mehr in die Buchung übernommen, wenn er n…

### DIFF
--- a/app/Models/BookkeepingBooking.php
+++ b/app/Models/BookkeepingBooking.php
@@ -368,7 +368,7 @@ class BookkeepingBooking extends Model
             $booking->date = $parent[$dateField];
         }
 
-        if (! $booking->number_range_document_numbers_id != $parent->number_range_document_numbers_id) {
+        if (!$booking->number_range_document_numbers_id  ||  $booking->number_range_document_numbers_id != $parent->number_range_document_numbers_id) {
             $booking->number_range_document_numbers_id = $parent->number_range_document_numbers_id;
         }
 


### PR DESCRIPTION
…icht bereits gefüllt war (Korrektur bei Rechnungen).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Behoben: Die Logik zur Zuweisung von Dokumentnummernbereich-IDs wurde korrigiert. Buchungen erben jetzt zuverlässig die Dokumentnummernbereich-ID von ihrer übergeordneten Buchung, wenn diese fehlt oder unterschiedlich ist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->