### PR TITLE
- In Angeboten wurde die Address als ['staße', 'ort'] angezeigt

### DIFF
--- a/app/Http/Controllers/App/OfferController.php
+++ b/app/Http/Controllers/App/OfferController.php
@@ -224,7 +224,7 @@ class OfferController extends Controller
 
         if ($request->validated('contact_id') !== $oldContactId) {
 
-            $offer->address = $offer->contact->getInvoiceAddress()->full_address;
+            $offer->address = $offer->contact->getFormatedInvoiceAddress();
             $offer->save();
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
  * Adressformatierung bei Angebotsaktualisierungen korrigiert: Wenn der Kontakt eines Angebots während der Bearbeitung geändert wird, wird die zugehörige Rechnungsadresse nun mit einheitlicher und standardisierter Formatierung gespeichert und angezeigt. Dies behebt potenzielle Darstellungsprobleme und verbessert die Datenkonsistenz in der Angebotsverwaltung.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->