### PR TITLE
Email löschen und in andere Dropbox verschieben

### DIFF
--- a/app/Http/Controllers/App/EmailController.php
+++ b/app/Http/Controllers/App/EmailController.php
@@ -9,7 +9,6 @@ use App\Data\SimpleContactData;
 use App\Http\Controllers\Controller;
 use App\Models\Contact;
 use App\Models\Dropbox;
-use App\Models\DropboxInbox;
 use App\Models\DropboxMail;
 use App\Models\Project;
 use Illuminate\Http\RedirectResponse;
@@ -27,7 +26,11 @@ class EmailController extends Controller
         }
 
         if ($mail) {
-            $mail = DropboxMail::query()->with('attachments')->with('dropbox')->where('id', $mail)->first();
+            $mail = DropboxMail::query()
+                ->with(['attachments', 'dropbox'])
+                ->whereKey($mail)
+                ->where('dropbox_id', $dropbox->id)
+                ->firstOrFail();
             if ($mail) {
                 if (! $mail->seen_at) {
                     $mail->seen_at = now();
@@ -54,27 +57,31 @@ class EmailController extends Controller
     /**
      * @throws Throwable
      */
-    public function move(Dropbox $dropbox, $mail, $newDropbox): RedirectResponse
+    public function move(Dropbox $dropbox, DropboxMail $mail, Dropbox $newDropbox): RedirectResponse
     {
-        if (! $dropbox->is_shared && $dropbox->user_id !== auth()->user()->id) {
+        if (
+            (! $dropbox->is_shared && $dropbox->user_id !== auth()->id())
+            || $mail->dropbox_id !== $dropbox->id
+            || (! $newDropbox->is_shared && $newDropbox->user_id !== auth()->id())
+        ) {
             abort(403);
         }
-
-        $mail = DropboxMail::query()->with('dropbox')->where('id', $mail)->first();
-        $mail->dropbox_id = $newDropbox;
+        $mail->dropbox_id = $newDropbox->id;
         $mail->save();
 
-        return redirect()->back();
+        return redirect(route('app.email.index', ['dropbox' => $dropbox->id]));
     }
 
     public function destroy(Dropbox $dropbox, DropboxMail $mail): RedirectResponse
     {
-        if (! $dropbox->is_shared && $dropbox->user_id !== auth()->user()->id) {
+        if (
+            (! $dropbox->is_shared && $dropbox->user_id !== auth()->id())
+            || $mail->dropbox_id !== $dropbox->id
+        ) {
             abort(403);
         }
-
         $mail->delete();
 
-        return redirect()->back();
+        return redirect(route('app.email.index', ['dropbox' => $dropbox->id]));
     }
 }

--- a/app/Http/Controllers/App/EmailController.php
+++ b/app/Http/Controllers/App/EmailController.php
@@ -7,7 +7,6 @@ use App\Data\DropboxMailData;
 use App\Data\ProjectData;
 use App\Data\SimpleContactData;
 use App\Http\Controllers\Controller;
-use App\Jobs\DropboxImportJob;
 use App\Models\Contact;
 use App\Models\Dropbox;
 use App\Models\DropboxInbox;
@@ -22,6 +21,10 @@ class EmailController extends Controller
 {
     public function index(Dropbox $dropbox, $mail = null): Response
     {
+
+        if (! $dropbox->is_shared && $dropbox->user_id !== auth()->user()->id) {
+            abort(403);
+        }
 
         if ($mail) {
             $mail = DropboxMail::query()->with('attachments')->with('dropbox')->where('id', $mail)->first();
@@ -39,7 +42,7 @@ class EmailController extends Controller
 
         $mails = DropboxMail::query()->where('dropbox_id', $dropbox->id)->orderBy('date', 'desc')->paginate();
 
-        return Inertia::render('App/Email/Index', [
+        return Inertia::render('App/Email/EmailIndex', [
             'mails' => DropboxMailData::collect($mails),
             'mail' => $mail ? DropboxMailData::from($mail) : null,
             'dropbox' => DropboxData::from($dropbox),
@@ -51,18 +54,27 @@ class EmailController extends Controller
     /**
      * @throws Throwable
      */
-    public function import($mail): RedirectResponse
+    public function move(Dropbox $dropbox, $mail, $newDropbox): RedirectResponse
     {
-        $mail = DropboxInbox::query()->with('dropbox')->where('id', $mail)->first();
-        DropboxImportJob::dispatch($mail);
+        if (! $dropbox->is_shared && $dropbox->user_id !== auth()->user()->id) {
+            abort(403);
+        }
 
-        return redirect()->route('app.inbox.index');
+        $mail = DropboxMail::query()->with('dropbox')->where('id', $mail)->first();
+        $mail->dropbox_id = $newDropbox;
+        $mail->save();
+
+        return redirect()->back();
     }
 
-    public function destroy(DropboxInbox $mail): RedirectResponse
+    public function destroy(Dropbox $dropbox, DropboxMail $mail): RedirectResponse
     {
+        if (! $dropbox->is_shared && $dropbox->user_id !== auth()->user()->id) {
+            abort(403);
+        }
+
         $mail->delete();
 
-        return redirect()->route('app.inbox.index');
+        return redirect()->back();
     }
 }

--- a/resources/js/Components/twc-ui/button.tsx
+++ b/resources/js/Components/twc-ui/button.tsx
@@ -46,7 +46,8 @@ const buttonVariants = tv({
         base: 'cursor-pointer text-primary underline-offset-4 data-[hovered]:underline'
       },
       'ghost-destructive': {
-        base: 'border border-transparent text-sm focus-visible:border focus-visible:border-input focus-visible:ring-ring/20 data-[hovered]:border-border data-[hovered]:bg-accent data-[hovered]:text-destructive-foreground'
+        base: 'border border-transparent sfocus-visible:border-input text-sm hover:stroke-destructive focus-visible:border focus-visible:ring-ring/20 data-[hovered]:border-border data-[hovered]:bg-accent data-[hovered]:text-destructive-foreground',
+        icon: 'text-primary hover:text-destructive'
       },
       toolbar: {
         base: 'border selected:border border-transparent selected:bg-muted text-primary text-sm focus-visible:border focus-visible:border-primary focus-visible:ring-ring/20 active:ring-ring/50 data-[hovered]:border-border data-[hovered]:bg-accent'

--- a/resources/js/Components/twc-ui/toolbar.tsx
+++ b/resources/js/Components/twc-ui/toolbar.tsx
@@ -59,16 +59,16 @@ export const Toolbar = ({ variant, isDisabled, ...props }: ToolbarProps) => {
 
 interface ToolbarButtonProps extends Omit<ButtonProps, 'variant'> {
   isDisabled?: boolean
-  variant?: 'default' | 'primary'
+  variant?: 'default' | 'primary' | 'ghost-destructive' | 'toolbar'
 }
 
 export const ToolbarButton = ({
-  variant = 'default',
+  variant = 'toolbar',
   isDisabled = false,
   ...props
 }: ToolbarButtonProps) => {
   const { isDisabled: isContextDisabled } = useToolbarContext()
-  const realVariant = variant === 'primary' ? 'toolbar-default' : 'toolbar'
+  const realVariant = variant === 'primary' ? 'toolbar-default' : variant
 
   return <Button variant={realVariant} isDisabled={isContextDisabled || isDisabled} {...props} />
 }

--- a/resources/js/Components/ui/sidebar.tsx
+++ b/resources/js/Components/ui/sidebar.tsx
@@ -566,6 +566,25 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) 
   )
 }
 
+function SidebarSubMenuBadge({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 font-medium text-sidebar-foreground text-xs tabular-nums',
+        'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
+        'peer-data-[size=sm]/menu-sub-button:-top-6',
+        'peer-data-[size=default]/menu-sub-button:top-0',
+        'peer-data-[size=lg]/menu-button:-top-6',
+        'group-data-[collapsible=icon]:hidden',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
 function SidebarMenuSkeleton({
   className,
   showIcon = false,
@@ -680,6 +699,7 @@ export {
   SidebarProvider,
   SidebarRail,
   SidebarSeparator,
+  SidebarSubMenuBadge,
   SidebarTrigger,
   useSidebar
 }

--- a/resources/js/Pages/App/Email/EmailIndex.tsx
+++ b/resources/js/Pages/App/Email/EmailIndex.tsx
@@ -1,12 +1,14 @@
-import { Delete02Icon, FolderUploadIcon } from '@hugeicons/core-free-icons'
-import { router } from '@inertiajs/react'
+import { Delete02Icon, MailSend02Icon } from '@hugeicons/core-free-icons'
+import { router, usePage } from '@inertiajs/react'
 import type * as React from 'react'
 import { PageContainerWithSideOnLeft } from '@/Components/PageContainerWithSideOnLeft'
 import { AlertDialog } from '@/Components/twc-ui/alert-dialog'
+import { DropdownButton } from '@/Components/twc-ui/dropdown-button'
+import { MenuItem } from '@/Components/twc-ui/menu'
 import { Toolbar, ToolbarButton } from '@/Components/twc-ui/toolbar'
 import type { PageProps } from '@/Types'
 import { Email } from './Email'
-import { IndexEntry } from './IndexEntry'
+import { EmailIndexEntry } from './EmailIndexEntry'
 
 interface InboxIndexProps extends PageProps {
   mails: App.Data.Paginated.PaginationMeta<App.Data.DropboxMailData[]>
@@ -16,7 +18,9 @@ interface InboxIndexProps extends PageProps {
   projects: App.Data.ProjectData[]
 }
 
-const Index: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails, projects }) => {
+const EmailIndex: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails, projects }) => {
+  const dropboxes = usePage().props.auth.dropboxes?.filter(item => item.id !== dropbox.id) || []
+
   const handleDelete = async () => {
     if (!mail) return
     const promise = await AlertDialog.call({
@@ -25,14 +29,39 @@ const Index: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails, proj
       buttonTitle: 'Löschen'
     })
     if (promise) {
-      router.delete(route('app.inbox.destroy', { mail: mail.id }))
+      router.delete(route('app.email.destroy', { dropbox: dropbox.id, mail: mail.id }))
     }
+  }
+
+  const handleMove = async (newDropbox: number) => {
+    if (!mail) return
+    router.put(route('app.email.move', { dropbox: dropbox.id, mail: mail.id, newDropbox }))
   }
 
   const toolbar = (
     <Toolbar isDisabled={!mail}>
-      <ToolbarButton variant="primary" icon={FolderUploadIcon} title="MultiDoc hochladen" />
-      <ToolbarButton icon={Delete02Icon} title="E-Mail löschen" onClick={handleDelete} />
+      <DropdownButton
+        variant="toolbar"
+        size="icon"
+        title="In andere Dropbox verschieben"
+        icon={MailSend02Icon}
+      >
+        {dropboxes.map(item => (
+          <MenuItem
+            key={item.email_address}
+            title={item.name}
+            ellipsis
+            onAction={() => handleMove(item.id as number)}
+          />
+        ))}
+      </DropdownButton>
+      <ToolbarButton
+        icon={Delete02Icon}
+        size="icon"
+        variant="ghost-destructive"
+        title="E-Mail löschen"
+        onClick={handleDelete}
+      />
     </Toolbar>
   )
 
@@ -47,7 +76,7 @@ const Index: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails, proj
         <div className="h-full overflow-y-auto">
           <div className="flex flex-col gap-2 p-4">
             {mails.data.map(item => (
-              <IndexEntry
+              <EmailIndexEntry
                 key={item.id}
                 dropbox={dropbox}
                 mail={item}
@@ -57,7 +86,7 @@ const Index: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails, proj
           </div>
         </div>
       </div>
-      <div className="absolute top-0 right-0 bottom-0 left-96 flex overflow-hidden">
+      <div className="absolute top-0 right-0 bottom-0 left-96 flex">
         <div className="mx-auto h-full overflow-y-auto">
           {mail && <Email mail={mail} contacts={contacts} projects={projects} />}
         </div>
@@ -66,4 +95,4 @@ const Index: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails, proj
   )
 }
 
-export default Index
+export default EmailIndex

--- a/resources/js/Pages/App/Email/EmailIndex.tsx
+++ b/resources/js/Pages/App/Email/EmailIndex.tsx
@@ -12,7 +12,7 @@ import { EmailIndexEntry } from './EmailIndexEntry'
 
 interface InboxIndexProps extends PageProps {
   mails: App.Data.Paginated.PaginationMeta<App.Data.DropboxMailData[]>
-  mail?: App.Data.DropboxMailData
+  mail?: App.Data.DropboxMailData | null
   dropbox: App.Data.DropboxData
   contacts: App.Data.ContactData[]
   projects: App.Data.ProjectData[]
@@ -45,6 +45,7 @@ const EmailIndex: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails,
         size="icon"
         title="In andere Dropbox verschieben"
         icon={MailSend02Icon}
+        isDisabled={!mail}
       >
         {dropboxes.map(item => (
           <MenuItem
@@ -56,6 +57,7 @@ const EmailIndex: React.FC<InboxIndexProps> = ({ contacts, dropbox, mail, mails,
         ))}
       </DropdownButton>
       <ToolbarButton
+        isDisabled={!mail}
         icon={Delete02Icon}
         size="icon"
         variant="ghost-destructive"

--- a/resources/js/Pages/App/Email/EmailIndexEntry.tsx
+++ b/resources/js/Pages/App/Email/EmailIndexEntry.tsx
@@ -9,7 +9,7 @@ interface InboxIndexEntryProps {
   dropbox: App.Data.DropboxData
 }
 
-export const IndexEntry: React.FC<InboxIndexEntryProps> = ({ dropbox, mail, isActive }) => {
+export const EmailIndexEntry: React.FC<InboxIndexEntryProps> = ({ dropbox, mail, isActive }) => {
   const handleClicked = () => {
     router.visit(route('app.email.index', { dropbox: dropbox.id, mail: mail.id }), {
       preserveScroll: true,

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -89,6 +89,8 @@ Route::middleware([
     Route::put('inbox/{mail}', [InboxController::class, 'import'])->name('app.inbox.import');
 
     Route::get('emails/{dropbox}/{mail?}', [EmailController::class, 'index'])->name('app.email.index');
+    Route::delete('emails/{dropbox}/{mail}', [EmailController::class, 'destroy'])->name('app.email.destroy');
+    Route::put('emails/{dropbox}/{mail}/{newDropbox}', [EmailController::class, 'move'])->name('app.email.move');
 
     Route::get('/onboarding', function () {
         return Inertia::modal('Onboarding')->baseRoute('app.soon');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * E-Mails können jetzt in eine andere Dropbox verschoben werden.
  * Für E-Mails steht eine neue Löschaktion mit aktualisierter Oberfläche zur Verfügung.
  * Die Seitenleiste erhält ein neues Badge-Element für Untermenüs.

* **Bug Fixes**
  * Der Zugriff auf die E-Mail-Ansicht ist jetzt strenger geschützt.
  * Die E-Mail-Ansicht nutzt aktualisierte Bezeichnungen und Navigation für konsistentere Bedienung.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->