### PR TITLE
Email-Anhang als Dokument importieren

### DIFF
--- a/app/Data/DocumentData.php
+++ b/app/Data/DocumentData.php
@@ -47,6 +47,7 @@ class DocumentData extends Data
         public readonly string $title,
         public readonly ?string $label,
         public readonly ?string $summary,
+        public readonly ?string $fulltext,
         public readonly ?string $reference,
         public readonly bool $is_pinned,
         public readonly bool $is_confirmed,

--- a/app/Data/DropboxData.php
+++ b/app/Data/DropboxData.php
@@ -22,6 +22,7 @@ class DropboxData extends Data
         public readonly bool $is_auto_processing,
         public readonly bool $is_private_by_default,
         public readonly ?int $user_id,
+        public readonly ?int $mails_count,
         public readonly ?UserData $user,
     ) {}
 }

--- a/app/Http/Controllers/App/EmailController.php
+++ b/app/Http/Controllers/App/EmailController.php
@@ -6,7 +6,9 @@ use App\Data\DropboxData;
 use App\Data\DropboxMailData;
 use App\Data\ProjectData;
 use App\Data\SimpleContactData;
+use App\Facades\FileHelperService;
 use App\Http\Controllers\Controller;
+use App\Jobs\DocumentUploadJob;
 use App\Jobs\ReceiptUploadFromMailAttchmentJob;
 use App\Models\Contact;
 use App\Models\Dropbox;
@@ -47,7 +49,7 @@ class EmailController extends Controller
             false)->with('mails')->orderBy('name')->orderBy('first_name')->get();
         $projects = Project::query()->where('is_archived', false)->orderBy('name')->get();
 
-        $mails = DropboxMail::query()->withCount('attachments')->where('dropbox_id', $dropbox->id)->orderBy('date', 'desc')->paginate();
+        $mails = DropboxMail::query()->withCount('attachments')->where('dropbox_id', $dropbox->id)->orderBy('date', 'desc')->paginate(50);
 
         return Inertia::render('App/Email/EmailIndex', [
             'mails' => DropboxMailData::collect($mails),
@@ -123,6 +125,33 @@ class EmailController extends Controller
             $media = $attachment->firstMedia('attachment');
             if ($media->exists()) {
                 ReceiptUploadFromMailAttchmentJob::dispatch($media);
+            }
+        } else {
+            abort(404);
+        }
+
+        return redirect()->back();
+    }
+
+    public function importAttachmentAsDocument(Dropbox $dropbox, DropboxMail $mail, DropboxMailAttachment $attachment): RedirectResponse
+    {
+        if (
+            (! $dropbox->is_shared && $dropbox->user_id !== auth()->id())
+            || $mail->dropbox_id !== $dropbox->id
+        ) {
+            abort(403);
+        }
+
+        if ($attachment->dropbox_mail_id !== $mail->id) {
+            abort(403);
+        }
+
+        if ($attachment->hasMedia('attachment')) {
+
+            $media = $attachment->firstMedia('attachment');
+            if ($media->exists()) {
+                $realPath = FileHelperService::createTemporaryFileFromDoc($media->filename, $media->contents());
+                DocumentUploadJob::dispatch($realPath, $media->filename, $media->size, $media->mime_type);
             }
         } else {
             abort(404);

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -70,8 +70,9 @@ class HandleInertiaRequests extends Middleware
 
             $mailAccounts = EmailAccount::query()->whereIn('id', $ids)->orderBy('email')->get();
 
-            $dropBoxes = Dropbox::query()->where('user_id', $user->id)->orWhere('is_shared', true)->orderBy('name')->get();
-
+            $dropBoxes = Dropbox::query()->withCount(['mails' => function ($query) {
+                $query->whereNull('seen_at');
+            }])->where('user_id', $user->id)->orWhere('is_shared', true)->orderBy('name')->get();
         }
 
         return [

--- a/app/Models/Dropbox.php
+++ b/app/Models/Dropbox.php
@@ -4,12 +4,15 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * @property-read \App\Models\User|null $user
+ * @property-read User|null $user
+ *
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Dropbox newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Dropbox newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Dropbox query()
+ *
  * @mixin \Eloquent
  */
 class Dropbox extends Model
@@ -21,7 +24,7 @@ class Dropbox extends Model
         'is_auto_processing',
         'token',
         'is_private_by_default',
-        'user_id'
+        'user_id',
     ];
 
     protected function casts(): array
@@ -44,4 +47,8 @@ class Dropbox extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function mails(): HasMany
+    {
+        return $this->hasMany(DropboxMail::class);
+    }
 }

--- a/app/Services/DocumentUploadService.php
+++ b/app/Services/DocumentUploadService.php
@@ -2,10 +2,10 @@
 
 namespace App\Services;
 
+use App\Facades\OcrService;
 use App\Models\Document;
 use Carbon\Carbon;
 use Exception;
-use App\Facades\OcrService;
 use Log;
 use Plank\Mediable\Exceptions\MediaUpload\ConfigurationException;
 use Plank\Mediable\Exceptions\MediaUpload\FileExistsException;
@@ -20,9 +20,7 @@ use Spatie\PdfToImage\Pdf;
 
 class DocumentUploadService
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     /**
      * @throws FileNotSupportedException
@@ -43,7 +41,7 @@ class DocumentUploadService
         ?string $sourceFile = null,
         ?string $fullText = null
     ): void {
-        $document = new Document();
+        $document = new Document;
         $document->filename = $fileName;
         $document->title = pathinfo($fileName)['filename'];
         $document->file_size = $fileSize;
@@ -57,9 +55,8 @@ class DocumentUploadService
 
         $document->save();
 
-
         try {
-            $parser = new Parser();
+            $parser = new Parser;
             $pdf = $parser->parseFile($file);
             $metadata = $pdf->getDetails();
 
@@ -69,12 +66,12 @@ class DocumentUploadService
                 $document->save();
             } else {
                 $document->fulltext = $pdf->getText();
-                if (!trim($document->fulltext)) {
-                    $document->fulltext = OcrService::run($file);
+                if (! trim($document->fulltext)) {
+                    $fullText = OcrService::run($file);
+                    $document->fulltext = $fullText;
                 }
                 $document->save();
             }
-
 
             if ($document->fulltext) {
                 try {
@@ -134,12 +131,11 @@ class DocumentUploadService
         }
 
         $document->checksum = hash_file('sha256', $file);
-        if (!$document->issued_on) {
+        if (! $document->issued_on) {
             $document->issued_on = $document->file_created_at;
         }
 
         $document->save();
-
 
         $media = MediaUploader::fromSource($file)
             ->toDestination('s3_private', 'documents/'.$document->issued_on->format('Y/m/'))

--- a/app/Services/OcrService.php
+++ b/app/Services/OcrService.php
@@ -13,16 +13,22 @@ class OcrService
      */
     public function run(string $file): string
     {
+        ray($file);
+
         $pages = $this->createImages($file);
         $fullText = '';
-        foreach ($pages as $page) {
-            $text = new TesseractOCR($page)
-                ->lang('eng', 'deu')
-                ->run();
-            $fullText .= $text;
-            unlink($page);
+        foreach ($pages as $i => $page) {
+            try {
+                $text = (new TesseractOCR($page))
+                    ->lang('eng', 'deu')
+                    ->run();
+                $fullText .= $text;
+            } catch (\Throwable $e) {
+                ray("Fehler auf Seite $i:", $e->getMessage());
+            } finally {
+                @unlink($page);
+            }
         }
-
         return $fullText;
     }
 

--- a/resources/js/Components/AppSidebar.tsx
+++ b/resources/js/Components/AppSidebar.tsx
@@ -39,18 +39,18 @@ const buildNavData = (isAdmin: boolean, dropboxes: App.Data.DropboxData[]) => ({
       url: route('app.inbox.index', {}, false),
       icon: MailAtSign02Icon,
       activePath: '/app/emails',
+      badge: dropboxes.reduce((sum, el) => (sum += el.mails_count || 0), 0),
       hasSep: true,
       items: [
         ...dropboxes.map(box => ({
           title: box.name,
-          badge: 5,
+          badge: box.mails_count as number,
           url: route('app.email.index', { dropbox: box.id }, false),
           activePath: `/app/emails/${box.id}`
         })),
         {
           title: 'Nicht verarbeitet',
           url: route('app.inbox.index'),
-          badge: 10,
           activePath: '/app/inbox'
         }
       ]

--- a/resources/js/Components/nav-main.tsx
+++ b/resources/js/Components/nav-main.tsx
@@ -17,7 +17,8 @@ import {
   SidebarMenuItem,
   SidebarMenuSub,
   SidebarMenuSubButton,
-  SidebarMenuSubItem
+  SidebarMenuSubItem,
+  SidebarSubMenuBadge
 } from '@/Components/ui/sidebar'
 import { usePathActive } from '@/Hooks/usePathActive'
 export type CombinedIcon = LucideIcon | React.FC<HugeiconsProps>
@@ -69,6 +70,7 @@ export function NavMain({ items, ...props }: { items: NavMainItem[] }) {
                           className="size-5! text-sidebar-foreground!"
                         />
                         <span className="text-base">{item.title}</span>
+                        {!!item.badge && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
                       </Link>
                     </SidebarMenuButton>
                   </CollapsibleTrigger>
@@ -93,6 +95,9 @@ export function NavMain({ items, ...props }: { items: NavMainItem[] }) {
                                       </Link>
                                     </SidebarMenuSubButton>
                                   </CollapsibleTrigger>
+                                  {!!subItem.badge && (
+                                    <SidebarSubMenuBadge>{subItem.badge}</SidebarSubMenuBadge>
+                                  )}
                                   <CollapsibleContent>
                                     <SidebarMenuSub className="ml-3 block">
                                       {subItem.items.map(child => (
@@ -109,7 +114,6 @@ export function NavMain({ items, ...props }: { items: NavMainItem[] }) {
                                               <span>{child.title}</span>
                                             </Link>
                                           </SidebarMenuSubButton>
-                                          <SidebarMenuBadge>{child.badge}</SidebarMenuBadge>
                                         </SidebarMenuSubItem>
                                       ))}
                                     </SidebarMenuSub>
@@ -133,6 +137,9 @@ export function NavMain({ items, ...props }: { items: NavMainItem[] }) {
                                   <span>{subItem.title}</span>
                                 </Link>
                               </SidebarMenuSubButton>
+                              {!!subItem.badge && (
+                                <SidebarSubMenuBadge>{subItem.badge}</SidebarSubMenuBadge>
+                              )}
                             </SidebarMenuSubItem>
                           )
                         })}

--- a/resources/js/Components/ui/sidebar.tsx
+++ b/resources/js/Components/ui/sidebar.tsx
@@ -575,6 +575,7 @@ function SidebarSubMenuBadge({ className, ...props }: React.ComponentProps<'div'
         'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 font-medium text-sidebar-foreground text-xs tabular-nums',
         'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
         'peer-data-[size=sm]/menu-sub-button:-top-6',
+        'peer-data-[size=md]/menu-sub-button:top-0',
         'peer-data-[size=default]/menu-sub-button:top-0',
         'peer-data-[size=lg]/menu-button:-top-6',
         'group-data-[collapsible=icon]:hidden',
@@ -664,7 +665,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md pl-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+        'peer/menu-sub-button flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md pl-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:font-medium',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',

--- a/resources/js/Pages/App/Email/EmailAttachment.tsx
+++ b/resources/js/Pages/App/Email/EmailAttachment.tsx
@@ -30,6 +30,16 @@ export const EmailAttachment: React.FC<EmailAttachmentsProps> = ({ attachment, m
     )
   }
 
+  const handleImportAsDocument = async () => {
+    router.put(
+      route('app.email.attachment-document', {
+        dropbox: mail.dropbox_id,
+        mail: mail.id,
+        attachment: attachment.id
+      })
+    )
+  }
+
   return (
     <div className="flex items-center space-x-2 px-3 py-1.5">
       <div className="flex-1 text-sm">{attachment.filename}</div>
@@ -38,7 +48,7 @@ export const EmailAttachment: React.FC<EmailAttachmentsProps> = ({ attachment, m
         <DropdownButton variant="ghost" size="icon-sm" title="Aktionen">
           <MenuItem title="Vorschau" separator onAction={handlePreview} />
           <MenuItem title="In Belegverwaltung übernehmen" onAction={handleImportAsReciept} />
-          <MenuItem title="In Dokumentverwaltung übernehmen" />
+          <MenuItem title="In Dokumentverwaltung übernehmen" onAction={handleImportAsDocument} />
         </DropdownButton>
       </div>
     </div>

--- a/resources/js/Types/generated.d.ts
+++ b/resources/js/Types/generated.d.ts
@@ -302,6 +302,7 @@ declare namespace App {
       readonly title: string;
       readonly label: string | null;
       readonly summary: string | null;
+      readonly fulltext: string | null;
       readonly reference: string | null;
       readonly is_pinned: boolean;
       readonly is_confirmed: boolean;
@@ -326,6 +327,7 @@ declare namespace App {
       readonly is_auto_processing: boolean;
       readonly is_private_by_default: boolean;
       readonly user_id: number | null;
+      readonly mails_count: number | null;
       readonly user: App.Data.UserData | null;
     };
     export type DropboxInboxAttachmentData = {

--- a/resources/typescript-transformer-manifest.json
+++ b/resources/typescript-transformer-manifest.json
@@ -1,3 +1,3 @@
 {
-    "js\/Types\/generated.d.ts": "5443b8151fccb353d728143398897642"
+    "js\/Types\/generated.d.ts": "7dfb08bcd6f32b10a5bd4b5203b48aca"
 }

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -93,6 +93,7 @@ Route::middleware([
     Route::put('emails/{dropbox}/{mail}/{newDropbox}', [EmailController::class, 'move'])->name('app.email.move');
     Route::get('emails/{dropbox}/{mail}/{attachment}/preview', [EmailController::class, 'attachmentPreview'])->name('app.email.attachment-preview');
     Route::put('emails/{dropbox}/{mail}/{attachment}/receipt', [EmailController::class, 'importAttachmentAsReceipt'])->name('app.email.attachment-receipt');
+    Route::put('emails/{dropbox}/{mail}/{attachment}/document', [EmailController::class, 'importAttachmentAsDocument'])->name('app.email.attachment-document');
 
     Route::get('/onboarding', function () {
         return Inertia::modal('Onboarding')->baseRoute('app.soon');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * E-Mails können jetzt direkt als Dokumente in die Dokumentverwaltung übernommen werden.
  * Die E-Mail-Navigation zeigt nun dynamische Zähler für ungelesene bzw. offene Mails an.

* **Bug Fixes**
  * PDF-Texte werden zuverlässiger verarbeitet; bei leeren Ergebnissen wird automatisch OCR eingesetzt.
  * OCR verarbeitet Seiten robuster und bricht bei einzelnen Fehlern nicht mehr komplett ab.

* **Änderungen**
  * Die E-Mail-Übersicht zeigt jetzt 50 Einträge pro Seite.
  * Dokumente und Dropboxen enthalten zusätzliche Status- und Textinformationen in der Oberfläche.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->