### PR TITLE
Im View Papierkorbe für Dokumente fehlten die Bulk-Aktionen zum endgü…

### DIFF
--- a/app/Http/Controllers/App/DocumentController.php
+++ b/app/Http/Controllers/App/DocumentController.php
@@ -220,7 +220,8 @@ class DocumentController extends Controller
         $ids = $request->getDocumentIds();
         Document::withTrashed()->whereIn('id', $ids)->restore();
 
-        return redirect()->back();
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Die Dokumente wurden wiederhergestellt.']);
+        return redirect()->route('app.document.index', ['view' => 'trash']);
     }
 
     public function restore(Document $document): RedirectResponse
@@ -353,23 +354,14 @@ class DocumentController extends Controller
 
         $document->forceDelete();
 
-        return redirect()->route('app.document.index', [
-            'filters' => [
-                'view' => [
-                    'operator' => 'scope',
-                    'value' => 'trash',
-                ],
-            ],
-        ])->with('success', 'Dokument wurde erfolgreich gelöscht.');
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Das Dokument wurde endgültig gelöscht.']);
+        return redirect()->route('app.document.index', ['view' => 'trash']);
     }
 
     public function bulkForceDelete(DocumentBulkMoveToTrashRequest $request): RedirectResponse
     {
         $ids = $request->getDocumentIds();
-        ray($ids);
-
         $documents = Document::whereIn('id', $ids)->withTrashed()->get();
-        ray($documents->toArray());
 
         $documents->each(function ($document) {
             $file = $document->firstMedia('file');
@@ -381,14 +373,8 @@ class DocumentController extends Controller
             $document->forceDelete();
         });
 
-        return redirect()->route('app.document.index', [
-            'filters' => [
-                'view' => [
-                    'operator' => 'scope',
-                    'value' => 'trash',
-                ],
-            ],
-        ])->with('success', 'Dokumente wurden erfolgreich gelöscht.');
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Die Dokumente wurden endgültig gelöscht.']);
+        return redirect()->route('app.document.index', ['view' => 'trash']);
     }
 
     /**

--- a/resources/js/Pages/App/Document/DocumentIndex.tsx
+++ b/resources/js/Pages/App/Document/DocumentIndex.tsx
@@ -83,8 +83,7 @@ const DocumentIndex: React.FC<DocumentIndexPageProps> = ({
   const getDocumentsByFolder = (folder: string) => documentsGroupedByFolder[folder]
 
   const getViewTitle = () => {
-    const view = routeFilters?.view?.value
-    switch (view) {
+    switch (route().params?.view) {
       case 'trash':
         return 'Papierkorb'
       case 'inbox':
@@ -95,8 +94,8 @@ const DocumentIndex: React.FC<DocumentIndexPageProps> = ({
   }
 
   const view = getViewTitle()
-  const isTrash = routeFilters?.view?.value === 'trash'
-  const isInbox = routeFilters?.view?.value === 'inbox'
+  const isTrash = route().params?.view === 'trash'
+  const isInbox = route().params?.view === 'inbox'
 
   const debouncedSearchChange = useCallback(
     (newSearch: string) => {

--- a/resources/js/Pages/App/Document/_Components/BulkActions.tsx
+++ b/resources/js/Pages/App/Document/_Components/BulkActions.tsx
@@ -31,6 +31,8 @@ export const BulkActions: React.FC<BulkActionsProps> = ({
 
   if (!selectedDocuments.length) return null
 
+  console.log('trash', trash)
+
   const handleBulkEdit = async () => {
     const result = await DocumentBulkEdit.call({
       contacts,


### PR DESCRIPTION
…ltigen löschen und wiederherstellen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wiederherstellen und endgültiges Löschen mehrerer Dokumente zeigen jetzt eine Erfolgsmeldung an und führen zurück zur Dokumentübersicht im Papierkorb.
  * Die Ansicht der Dokumentliste erkennt den aktuellen Tab zuverlässiger und zeigt die passenden Titel für Papierkorb, Inbox und Dokumente korrekt an.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->