### PR TITLE
ZIP-Download von gefilterterten Belegen

### DIFF
--- a/app/Http/Controllers/App/Bookkeeping/ReceiptController.php
+++ b/app/Http/Controllers/App/Bookkeeping/ReceiptController.php
@@ -11,6 +11,7 @@ use App\Data\ReceiptData;
 use App\Data\TransactionData;
 use App\Facades\BookeepingRuleService;
 use App\Facades\PdfService;
+use App\Facades\WeasyPdfService;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ReceiptsBulkDeleteRequest;
 use App\Http\Requests\ReceiptUpdateRequest;
@@ -136,7 +137,7 @@ class ReceiptController extends Controller
 
         $activeFilters = (new Receipt)->getActiveFilterLabels($request, ['Suche']);
 
-        $pdf = PdfService::createPdf('receipt-report', 'pdf.receipts.report',
+        $pdf = WeasyPdfService::createPdf('receipt-report', 'pdf.receipts.report',
             [
                 'receipts' => $receipts,
                 'activeFilters' => $activeFilters,
@@ -163,6 +164,26 @@ class ReceiptController extends Controller
         $filename = now()->format('Y-m-d-H-i').'-Auswertung-Kostenstellen.pdf';
 
         return response()->inlineFile($pdf, $filename);
+    }
+
+    public function downloadFilteredReceipts(Request $request): RedirectResponse
+    {
+        $search = $request->input('search', '');
+        $query = Receipt::query();
+        $this->applyReceiptQueryFilters($query, $request, $search);
+        $receipts = $query->get();
+
+        $ids = $receipts->pluck('id')->toArray();
+        $download = DocumentDownload::create([
+            'type' => 'receipt',
+            'ids' => $ids,
+        ]);
+
+        DownloadJob::dispatch($download->id, auth()->user());
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Dein Download wird erstellt.']);
+
+        return redirect()->back();
+
     }
 
     /**

--- a/app/Services/DownloadService.php
+++ b/app/Services/DownloadService.php
@@ -44,7 +44,7 @@ class DownloadService
             $content = $media->contents();
 
             if ($receipt->document_number) {
-                $zip->addFromString($receipt->document_number.'.pdf', $content);
+                $zip->addFromString($receipt->issued_on->format('Ymd-').$receipt->document_number.'.pdf', $content);
             }
         }
 

--- a/resources/js/Pages/App/Bookkeeping/Receipt/ReceiptIndex.tsx
+++ b/resources/js/Pages/App/Bookkeeping/Receipt/ReceiptIndex.tsx
@@ -4,7 +4,8 @@ import {
   Invoice01Icon,
   MagicWand01Icon,
   PrinterIcon,
-  Tick01Icon
+  Tick01Icon,
+  Zip01Icon
 } from '@hugeicons/core-free-icons'
 import { router } from '@inertiajs/react'
 import { sumBy } from 'lodash'
@@ -106,6 +107,16 @@ const ReceiptIndex: React.FC<ReceiptIndexPageProps> = ({
     )
   }, [selectedRows])
 
+  const handleDownload = useCallback(async () => {
+    const url = route('app.bookkeeping.filter-download', {
+      filters: filters.filters,
+      boolean: filters.boolean || 'AND',
+      search: search
+    })
+
+    router.visit(url)
+  }, [search, filters.filters, filters.boolean])
+
   const handlePrint = useCallback(async () => {
     const url = route('app.bookkeeping.receipts.print', {
       filters: filters.filters,
@@ -179,9 +190,15 @@ const ReceiptIndex: React.FC<ReceiptIndexPageProps> = ({
     () => (
       <Toolbar>
         <Button variant="ghost" icon={PrinterIcon} title="Drucken" onClick={handlePrint} />
+        <Button
+          variant="toolbar"
+          icon={Zip01Icon}
+          title="Belege als ZIP-Archiv herunterladen"
+          onClick={handleDownload}
+        />
       </Toolbar>
     ),
-    [handlePrint]
+    [handlePrint, handleDownload]
   )
   const actionBar = useMemo(() => {
     const sum = sumBy(selectedRows, 'amount')

--- a/routes/tenant/bookkeeping.php
+++ b/routes/tenant/bookkeeping.php
@@ -52,6 +52,8 @@ Route::get('/bookkeeping/receipts/report', [ReceiptController::class, 'printRepo
 Route::put('/bookkeeping/receipts/lock/{receipt?}', [ReceiptController::class, 'lock'])->name('app.bookkeeping.receipts.lock');
 Route::put('/bookkeeping/receipts/rule/', [ReceiptController::class, 'runRules'])->name('app.bookkeeping.receipts.rule');
 
+
+
 Route::get('/bookkeeping/receipts/confirm/', [ReceiptController::class, 'confirmFirst'])->name('app.bookkeeping.receipts.confirm-first');
 Route::put('/bookkeeping/receipts/confirm/{receipt}/update', [ReceiptController::class, 'update'])->name('app.bookkeeping.receipts.update')->middleware([HandlePrecognitiveRequests::class]);
 Route::get('/bookkeeping/receipts/{receipt}/pdf', [ReceiptController::class, 'streamPdf'])->name('app.bookkeeping.receipts.pdf');
@@ -64,6 +66,7 @@ Route::put('/bookkeeping/receipts/{receipt}/extract-with-ai', [ReceiptController
 Route::get('/bookkeeping/receipts/confirm/{receipt}', [ReceiptController::class, 'confirm'])->name('app.bookkeeping.receipts.confirm');
 Route::get('/bookkeeping/receipts/{receipt}/edit', [ReceiptController::class, 'edit'])->name('app.bookkeeping.receipts.edit');
 Route::get('/bookkeeping/receipts/bulk-download/', [ReceiptController::class, 'bulkDownload'])->name('app.bookkeeping.bulk-download');
+Route::get('/bookkeeping/receipts/filter-download/', [ReceiptController::class, 'downloadFilteredReceipts'])->name('app.bookkeeping.filter-download');
 Route::put('/bookkeeping/receipts/{receipt}/unlock', [ReceiptController::class, 'unlock'])->name('app.bookkeeping.receipts.unlock');
 Route::delete('/bookkeeping/receipts/{receipt}/payment/{transaction}', [ReceiptController::class, 'destroyPayment'])->name('app.bookkeeping.receipts.delete-payment');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Belege können anhand der aktuellen Filter- und Suchkriterien als ZIP-Archiv heruntergeladen werden.
  * Der Download wird nach dem Start automatisch im Hintergrund erstellt.
* **Verbesserungen**
  * PDF-Reports werden mit einer verbesserten PDF-Erstellung generiert.
  * Dateien im ZIP-Archiv enthalten nun das Ausstellungsdatum im Dateinamen, z. B. `20240131-12345.pdf`.
* **Benutzeroberfläche**
  * In der Belegübersicht steht ein neuer Button zum Herunterladen der gefilterten Belege bereit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->